### PR TITLE
Remove license_models

### DIFF
--- a/lib/Search/SearchImages.rb
+++ b/lib/Search/SearchImages.rb
@@ -6,7 +6,7 @@ class SearchImages < RequestBase
 
 	API_ROUTE = "/v3/search/images" # mashery endpoint
 	QUERY_PARAMS_NAMES = ["age_of_people","artists","collection_codes","collections_filter_type","color","compositions","embed_content_only","ethnicity","event_ids","exclude_nudity","fields",
-		"file_types","graphical_styles","keyword_ids","license_models","minimum_size","number_of_people","orientations","page","page_size","phrase","prestige_content_only","product_types",
+		"file_types","graphical_styles","keyword_ids","minimum_size","number_of_people","orientations","page","page_size","phrase","prestige_content_only","product_types",
 		"sort_order","specific_people"]
 
 	QUERY_PARAMS_NAMES.each do |key|

--- a/lib/Search/SearchImagesCreative.rb
+++ b/lib/Search/SearchImagesCreative.rb
@@ -6,7 +6,7 @@ class SearchImagesCreative < RequestBase
 
 	API_ROUTE = "/v3/search/images/creative" # mashery endpoint	
     QUERY_PARAMS_NAMES = ["age_of_people","artists","collection_codes","collections_filter_type","color","compositions","embed_content_only","ethnicity","exclude_nudity","fields","file_types",
-        "graphical_styles","keyword_ids","license_models","minimum_size","number_of_people","orientations","page","page_size","phrase","prestige_content_only","product_types",
+        "graphical_styles","keyword_ids","minimum_size","number_of_people","orientations","page","page_size","phrase","prestige_content_only","product_types",
         "sort_order"]
 
 	QUERY_PARAMS_NAMES.each do |key|

--- a/unit_tests/SearchImagesCreativeTests.rb
+++ b/unit_tests/SearchImagesCreativeTests.rb
@@ -178,18 +178,6 @@ class SearchImagesCreativeTests < Test::Unit::TestCase
         assert_equal({"message" => "success"}, search_results.to_hash )
     end
 
-    def test_search_images_creative_with_license_models
-        stub_request(:get, "https://api.gettyimages.com/v3/search/images/creative").with(query: {"license_models" => ["rightsmanaged", "royaltyfree"].join(",")})
-            .to_return(body: '{ "message": "success" }')
-
-        apiClient 		= ApiClient.new("api key", "api secret")
-        search_results	= apiClient.search_images_creative()
-                            .with_license_models(["rightsmanaged", "royaltyfree"])
-                            .execute()
-
-        assert_equal({"message" => "success"}, search_results.to_hash )
-    end
-
     def test_search_images_creative_with_minimum_size
         stub_request(:get, "https://api.gettyimages.com/v3/search/images/creative").with(query: {"minimum_size" => "small"})
             .to_return(body: '{ "message": "success" }')

--- a/unit_tests/SearchImagesTests.rb
+++ b/unit_tests/SearchImagesTests.rb
@@ -191,18 +191,6 @@ class SearchImagesTests < Test::Unit::TestCase
         assert_equal({"message" => "success"}, search_results.to_hash )
     end
 
-    def test_search_images_with_license_models
-        stub_request(:get, "https://api.gettyimages.com/v3/search/images").with(query: {"license_models" => ["rightsmanaged", "royaltyfree"].join(",")})
-            .to_return(body: '{ "message": "success" }')
-
-        apiClient 		= ApiClient.new("api key", "api secret")
-        search_results	= apiClient.search_images()
-                            .with_license_models(["rightsmanaged", "royaltyfree"])
-                            .execute()
-
-        assert_equal({"message" => "success"}, search_results.to_hash )
-    end
-
     def test_search_images_with_minimum_size
         stub_request(:get, "https://api.gettyimages.com/v3/search/images").with(query: {"minimum_size" => "small"})
             .to_return(body: '{ "message": "success" }')


### PR DESCRIPTION
Remove license_models from SearchImages and SearchImagesCreative.
Remove license_models unit tests to reflect the new behavior