### PR TITLE
Update to supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
+rvm:
+  - 2.5
+  - 2.6
+  - 2.7
 sudo: false
 script:
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ -n "$TRAVIS_TAG" ]; then PACKAGE_VERSION=$TRAVIS_TAG;

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,22 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    hashdiff (0.3.7)
-    json (1.8.6)
-    power_assert (1.1.1)
-    public_suffix (3.0.2)
-    rake (12.3.0)
-    safe_yaml (1.0.4)
-    test-unit (3.2.7)
+    hashdiff (1.0.0)
+    json (2.3.0)
+    power_assert (1.1.6)
+    public_suffix (4.0.3)
+    rake (13.0.1)
+    safe_yaml (1.0.5)
+    test-unit (3.3.5)
       power_assert
-    webmock (3.3.0)
+    webmock (3.8.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
@@ -31,4 +31,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ _Source code is only needed if you would like to contribute to the project. Othe
 
 ### Requirements
 
-- Ruby version >= 2.4
+- Ruby version >= 2.5
 - [Bundler](http://bundler.io)
 
 Install bundler and all dependencies


### PR DESCRIPTION
EOL for 2.4 is 2020.03.31. This bumps the minimum to 2.5.
Also updates the dependecy versions and the readme.

Testing in Travis is added for all the supported versions.

[Supported Ruby Branches](https://www.ruby-lang.org/en/downloads/branches/)