### PR TITLE
Allow custom parameters and headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
+shell = /bin/sh
+UID := $(shell id -u)
+GID := $(shell id -g)
+
 build:
 	bundle config set --local path 'vendor/bundle'
 	bundle install --path vendor/bundle
 	bundle exec rake
 	gem build gettyimages-api.gemspec
+
+
+# Run a Ruby container with the current directory mounted and as the
+# current user. This allows development without installing Ruby on your
+# system or if you have a version of Ruby not supported by the SDK.
+docker:
+	env UID=${UID} GID=${UID} docker run -it --net=host -v /${PWD}:/workdir -w //workdir -u ${UID}:${GID} ruby:2.7 /bin/bash
+	

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ build:
 	bundle exec rake
 	gem build gettyimages-api.gemspec
 
+test:
+	rake
 
 # Run a Ruby container with the current directory mounted and as the
 # current user. This allows development without installing Ruby on your

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ api_secret = "API Secret"
 # create instance of the SDK
 apiClient = ApiClient.new(api_key, api_secret)
 result = apiClient
-    .search_images()
+    .search_images_creative()
     .with_phrase("gorilla")
     .with_fields(["artist", "id", "title"])
     .with_exclude_nudity("true")
@@ -107,6 +107,18 @@ result = apiClient
     .execute()
 
 puts result["uri"]
+```
+
+### Make a request using custom parameter and header
+
+```ruby
+apiClient = ApiClient.new(api_key, api_secret)
+result = apiClient
+    .search_images_creative()
+    .with_phrase("beach")
+    .with_custom_parameter("safe_search", "true")
+    .with_custom_header("gi-country-code", "CAN")
+    .execute()
 ```
 
 ### Use the custom request functionality for GET request with query parameters

--- a/lib/Downloads/DownloadImages.rb
+++ b/lib/Downloads/DownloadImages.rb
@@ -2,12 +2,12 @@ require_relative "../RequestBase.rb"
 
 class DownloadImages < RequestBase
 
-    attr_accessor :asset_id, :accept_language
+    attr_accessor :asset_id
 
-	API_ROUTE = "/v3/downloads/images" # mashery endpoint	
-	QUERY_PARAMS_NAMES = ["file_type","height","product_id","product_type"]	
+	API_ROUTE = "/v3/downloads/images"
+	QUERY_PARAM_NAMES = ["file_type","height","product_id","product_type"]	
 
-	QUERY_PARAMS_NAMES.each do |key|
+	QUERY_PARAM_NAMES.each do |key|
     define_method :"with_#{key}" do |value = true| 
             if (!key.include? "id") && (value.is_a?(String))
                 value.downcase!
@@ -23,16 +23,10 @@ class DownloadImages < RequestBase
         return self
     end
 
-    public
-	def with_accept_language(language)
-		@accept_language = {"Accept-Language" => language}
-		return self
-	end
-
     def execute
         build_query_params("auto_download", "false")
         uri = API_ROUTE + "/" + self.asset_id
-		return @http_helper.post(uri, @query_params, nil, accept_language)			
+		return @http_helper.post(uri, @query_params, nil, @headers)			
 	end
 
 end

--- a/lib/Downloads/DownloadImages.rb
+++ b/lib/Downloads/DownloadImages.rb
@@ -8,7 +8,7 @@ class DownloadImages < RequestBase
 	QUERY_PARAM_NAMES = ["file_type","height","product_id","product_type"]	
 
 	QUERY_PARAM_NAMES.each do |key|
-    define_method :"with_#{key}" do |value = true| 
+        define_method :"with_#{key}" do |value = true| 
             if (!key.include? "id") && (value.is_a?(String))
                 value.downcase!
             end	

--- a/lib/Downloads/DownloadVideos.rb
+++ b/lib/Downloads/DownloadVideos.rb
@@ -2,20 +2,17 @@ require_relative "../RequestBase.rb"
 
 class DownloadVideos < RequestBase
 
-    attr_accessor :asset_id, :accept_language
+    attr_accessor :asset_id
 
-	API_ROUTE = "/v3/downloads/videos" # mashery endpoint	
-	QUERY_PARAMS_NAMES = ["product_id","size"]	
+	API_ROUTE = "/v3/downloads/videos"
+	QUERY_PARAM_NAMES = ["product_id","size"]	
 
-	QUERY_PARAMS_NAMES.each do |key|
-    define_method :"with_#{key}" do |value = true| 
-            if (!key.include? "id") && (value.is_a?(String))
-                value.downcase!
-            end	
-            build_query_params(key, value)
-            return self
-        end
-    end
+	QUERY_PARAM_NAMES.each do |key|
+		define_method :"with_#{key}" do |value = true| 
+			add_parameter(key, value)
+			return self
+		end
+	end
       
     public 	
     def with_id(asset_id)	
@@ -23,16 +20,10 @@ class DownloadVideos < RequestBase
         return self
     end
 
-    public
-	def with_accept_language(language)
-		@accept_language = {"Accept-Language" => language}
-		return self
-	end
-
     def execute
         build_query_params("auto_download", "false")
         uri = API_ROUTE + "/" + self.asset_id
-		return @http_helper.post(uri, @query_params, nil, accept_language)			
+		return @http_helper.post(uri, @query_params, nil, @headers)			
 	end
 
 end

--- a/lib/Images/Images.rb
+++ b/lib/Images/Images.rb
@@ -2,21 +2,17 @@ require_relative "../RequestBase.rb"
 
 class Images < RequestBase
 
-    attr_accessor :asset_id, :accept_language
+    attr_accessor :asset_id
 
-	API_ROUTE = "/v3/images" # mashery endpoint	
-	QUERY_PARAMS_NAMES = ["ids","fields"]
+	API_ROUTE = "/v3/images"
+	QUERY_PARAM_NAMES = ["ids","fields"]
 
-	QUERY_PARAMS_NAMES.each do |key|
-    define_method :"with_#{key}" do |value = true| 
-            value = value.join(",")
-            if !key.include? "id"
-                value.downcase!
-            end	
-            build_query_params(key, value)
-    		return self
-    	end
-  	end
+	QUERY_PARAM_NAMES.each do |key|
+		define_method :"with_#{key}" do |value = true| 
+			add_parameter(key, value)
+			return self
+		end
+	end
 			
 	public 
     def with_id(id)
@@ -24,16 +20,11 @@ class Images < RequestBase
 		return self
 	end
 
-	public
-	def with_accept_language(language)
-		@accept_language = {"Accept-Language" => language}
-		return self
-	end
 
 	public
     def execute
         self.asset_id.nil? ? uri = API_ROUTE : uri = API_ROUTE + "/" + self.asset_id
-		return @http_helper.get(uri, @query_params, @accept_language)			
+		return @http_helper.get(uri, @query_params, @headers)			
 	end
 
 end

--- a/lib/RequestBase.rb
+++ b/lib/RequestBase.rb
@@ -2,13 +2,14 @@ require_relative "HttpHelper"
 
 class RequestBase
 
-	attr_accessor :http_helper, :query_params
+	attr_accessor :http_helper, :query_params, :headers
 
 	def initialize(api_key, access_token)
 		
 		#puts "here is my token #{access_token}" 		
 		@http_helper = HttpHelper.new(api_key, access_token)						
 		@query_params = Hash.new
+		@headers = Hash.new
 
 	end	
 
@@ -17,4 +18,37 @@ class RequestBase
 		@query_params[key].nil? ? @query_params[key] = value : @query_params[key] << "," + value
 	end 
 
+	protected
+	def add_parameter(key, value)
+		if value.is_a?(Array)
+			value = value.join(",")
+			if (!key.include? "id") && (!key.include? "orientations")
+				value.downcase!
+			end	
+			build_query_params(key, value)
+		else
+			if (!key.include? "id") && (!key.include? "orientations") && (value.is_a?(String))
+				value.downcase!
+			end	
+			build_query_params(key, value)
+		end
+	end
+
+	public
+	def with_accept_language(language)
+		@headers["Accept-Language"] = language
+		return self
+	end
+
+	public
+	def with_custom_header(key, value)
+		@headers[key] = value
+		return self
+	end
+
+	public
+	def with_custom_parameter(key, value)
+		add_parameter(key, value)
+		return self
+	end
 end

--- a/lib/Search/SearchImages.rb
+++ b/lib/Search/SearchImages.rb
@@ -2,38 +2,20 @@ require_relative "../RequestBase.rb"
 
 class SearchImages < RequestBase
 
-	attr_accessor :accept_language
-
 	API_ROUTE = "/v3/search/images" # mashery endpoint
-	QUERY_PARAMS_NAMES = ["age_of_people","artists","collection_codes","collections_filter_type","color","compositions","embed_content_only","ethnicity","event_ids","exclude_nudity","fields",
+	QUERY_PARAM_NAMES = ["age_of_people","artists","collection_codes","collections_filter_type","color","compositions","embed_content_only","ethnicity","event_ids","exclude_nudity","fields",
 		"file_types","graphical_styles","keyword_ids","minimum_size","number_of_people","orientations","page","page_size","phrase","prestige_content_only","product_types",
 		"sort_order","specific_people"]
-
-	QUERY_PARAMS_NAMES.each do |key|
-    define_method :"with_#{key}" do |value = true| 
-			if value.is_a?(Array)
-				value = value.join(",")
-				if (!key.include? "id") && (!key.include? "orientations")
-					value.downcase!
-				end	
-    			build_query_params(key, value)
-			else
-				if (!key.include? "id") && (!key.include? "orientations") && (value.is_a?(String))
-					value.downcase!
-				end	
-    			build_query_params(key, value)
-    		end
-    		return self
-    	end
-	end
-			  
-	def with_accept_language(language)
-		@accept_language = {"Accept-Language" => language}
-		return self
+	
+	QUERY_PARAM_NAMES.each do |key|
+		define_method :"with_#{key}" do |value = true| 
+			add_parameter(key, value)
+			return self
+		end
 	end
 
 	def execute
-		return @http_helper.get(API_ROUTE, @query_params, @accept_language)			
+		return @http_helper.get(API_ROUTE, @query_params, @headers)			
 	end
 
 end

--- a/lib/Search/SearchImagesCreative.rb
+++ b/lib/Search/SearchImagesCreative.rb
@@ -2,38 +2,24 @@ require_relative "../RequestBase.rb"
 
 class SearchImagesCreative < RequestBase
 
-	attr_accessor :accept_language
+	QUERY_PARAM_NAMES = ["age_of_people","artists","collection_codes","collections_filter_type","color","compositions","embed_content_only","ethnicity","exclude_nudity","fields","file_types",
+		"graphical_styles","keyword_ids","minimum_size","number_of_people","orientations","page","page_size","phrase","prestige_content_only","product_types",
+		"sort_order"]
 
-	API_ROUTE = "/v3/search/images/creative" # mashery endpoint	
-    QUERY_PARAMS_NAMES = ["age_of_people","artists","collection_codes","collections_filter_type","color","compositions","embed_content_only","ethnicity","exclude_nudity","fields","file_types",
-        "graphical_styles","keyword_ids","minimum_size","number_of_people","orientations","page","page_size","phrase","prestige_content_only","product_types",
-        "sort_order"]
-
-	QUERY_PARAMS_NAMES.each do |key|
-    define_method :"with_#{key}" do |value = true| 
-			if value.is_a?(Array)
-				value = value.join(",")
-				if (!key.include? "id") && (!key.include? "orientations")
-					value.downcase!
-				end	
-    			build_query_params(key, value)
-			else
-				if (!key.include? "id") && (!key.include? "orientations") && (value.is_a?(String))
-					value.downcase!
-				end	
-    			build_query_params(key, value)
-    		end
-    		return self
-    	end
-	  end
-	  		  
-	def with_accept_language(language)
-		@accept_language = {"Accept-Language" => language}
-		return self
+	def initialize(api_key, access_token)
+		super
+		@api_route = "/v3/search/images/creative"
 	end
 
+	QUERY_PARAM_NAMES.each do |key|
+    define_method :"with_#{key}" do |value = true| 
+			add_parameter(key, value)
+    		return self
+    	end
+	end
+	  		  
 	def execute
-		return @http_helper.get(API_ROUTE, @query_params, @accept_language)			
+		return @http_helper.get(@api_route, @query_params, @headers)			
 	end
 
 end

--- a/lib/Search/SearchImagesCreative.rb
+++ b/lib/Search/SearchImagesCreative.rb
@@ -12,10 +12,10 @@ class SearchImagesCreative < RequestBase
 	end
 
 	QUERY_PARAM_NAMES.each do |key|
-    define_method :"with_#{key}" do |value = true| 
+		define_method :"with_#{key}" do |value = true| 
 			add_parameter(key, value)
-    		return self
-    	end
+			return self
+		end
 	end
 	  		  
 	def execute

--- a/lib/Search/SearchImagesEditorial.rb
+++ b/lib/Search/SearchImagesEditorial.rb
@@ -2,38 +2,21 @@ require_relative "../RequestBase.rb"
 
 class SearchImagesEditorial < RequestBase
 
-	attr_accessor :accept_language
-
-	API_ROUTE = "/v3/search/images/editorial" # mashery endpoint	
-    QUERY_PARAMS_NAMES = ["age_of_people","artists","collection_codes","collections_filter_type","compositions","editorial_segments","embed_content_only","end_date","entity_uris","ethnicity",
+	API_ROUTE = "/v3/search/images/editorial"
+    QUERY_PARAM_NAMES = ["age_of_people","artists","collection_codes","collections_filter_type","compositions","editorial_segments","embed_content_only","end_date","entity_uris","ethnicity",
         "event_ids","exclude_nudity","fields","file_types","graphical_styles","keyword_ids","minimum_quality_rank","minimum_size","number_of_people","orientations","page","page_size","phrase",
         "product_types","sort_order","specific_people","start_date"]
 
-	QUERY_PARAMS_NAMES.each do |key|
-    define_method :"with_#{key}" do |value = true| 
-			if value.is_a?(Array)
-				value = value.join(",")
-				if (!key.include? "id") && (!key.include? "orientations")
-					value.downcase!
-				end	
-    			build_query_params(key, value)
-			else
-				if (!key.include? "id") && (!key.include? "orientations") && (value.is_a?(String))
-					value.downcase!
-				end	
-    			build_query_params(key, value)
-    		end
-    		return self
-    	end
+	QUERY_PARAM_NAMES.each do |key|
+		define_method :"with_#{key}" do |value = true| 
+			add_parameter(key, value)
+			return self
+		end
 	end
 
-	def with_accept_language(language)
-		@accept_language = {"Accept-Language" => language}
-		return self
-	end
-	  
+
 	def execute
-		return @http_helper.get(API_ROUTE, @query_params, @accept_language)			
+		return @http_helper.get(API_ROUTE, @query_params, @headers)			
 	end
 
 end

--- a/lib/Search/SearchVideos.rb
+++ b/lib/Search/SearchVideos.rb
@@ -1,38 +1,20 @@
 require_relative "../RequestBase.rb"
 
 class SearchVideos < RequestBase
-
-	attr_accessor :accept_language
 	
-	API_ROUTE = "/v3/search/videos" # mashery endpoint	
-    QUERY_PARAMS_NAMES = ["age_of_people","collection_codes","collections_filter_type","editorial_video_types","exclude_nudity","fields","format_available","frame_rates",
+	API_ROUTE = "/v3/search/videos"
+    QUERY_PARAM_NAMES = ["age_of_people","collection_codes","collections_filter_type","editorial_video_types","exclude_nudity","fields","format_available","frame_rates",
         "keyword_ids","license_models","page","page_size","phrase","product_types","sort_order","specific_people"]
 
-	QUERY_PARAMS_NAMES.each do |key|
-    define_method :"with_#{key}" do |value = true| 
-			if value.is_a?(Array)
-				value = value.join(",")
-				if !key.include? "id"
-					value.downcase!
-				end	
-    			build_query_params(key, value)
-			else
-				if (!key.include? "id") && (value.is_a?(String))
-					value.downcase!
-				end	
-    			build_query_params(key, value)
-    		end
-    		return self
-    	end
-	end
-	
-	def with_accept_language(language)
-		@accept_language = {"Accept-Language" => language}
-		return self
+	QUERY_PARAM_NAMES.each do |key|
+		define_method :"with_#{key}" do |value = true| 
+			add_parameter(key, value)
+			return self
+		end
 	end
 
 	def execute
-		return @http_helper.get(API_ROUTE, @query_params, @accept_language)			
+		return @http_helper.get(API_ROUTE, @query_params, @headers)			
 	end
 
 end

--- a/lib/Search/SearchVideosCreative.rb
+++ b/lib/Search/SearchVideosCreative.rb
@@ -2,37 +2,19 @@ require_relative "../RequestBase.rb"
 
 class SearchVideosCreative < RequestBase
 
-	attr_accessor :accept_language
-
-	API_ROUTE = "/v3/search/videos/creative" # mashery endpoint	
-    QUERY_PARAMS_NAMES = ["age_of_people","collection_codes","collections_filter_type","exclude_nudity","fields","format_available","frame_rates",
+	API_ROUTE = "/v3/search/videos/creative"
+    QUERY_PARAM_NAMES = ["age_of_people","collection_codes","collections_filter_type","exclude_nudity","fields","format_available","frame_rates",
         "keyword_ids","license_models","page","page_size","phrase","product_types","sort_order"]
 
-	QUERY_PARAMS_NAMES.each do |key|
-    define_method :"with_#{key}" do |value = true| 
-			if value.is_a?(Array)
-				value = value.join(",")
-				if !key.include? "id"
-					value.downcase!
-				end	
-    			build_query_params(key, value)
-			else
-				if (!key.include? "id") && (value.is_a?(String))
-					value.downcase!
-				end	
-    			build_query_params(key, value)
-    		end
-    		return self
-    	end
-	  end
-	  
-	def with_accept_language(language)
-		@accept_language = {"Accept-Language" => language}
-		return self
+	QUERY_PARAM_NAMES.each do |key|
+		define_method :"with_#{key}" do |value = true| 
+			add_parameter(key, value)
+			return self
+		end
 	end
-
+	  
 	def execute
-		return @http_helper.get(API_ROUTE, @query_params, @accept_language)			
+		return @http_helper.get(API_ROUTE, @query_params, @headers)			
 	end
 
 end

--- a/lib/Search/SearchVideosEditorial.rb
+++ b/lib/Search/SearchVideosEditorial.rb
@@ -2,37 +2,19 @@ require_relative "../RequestBase.rb"
 
 class SearchVideosEditorial < RequestBase
 
-	attr_accessor :accept_language
-
-	API_ROUTE = "/v3/search/videos/editorial" # mashery endpoint	
-    QUERY_PARAMS_NAMES = ["age_of_people","collection_codes","collections_filter_type","editorial_video_types","entity_uris","exclude_nudity","fields","format_available","frame_rates",
+	API_ROUTE = "/v3/search/videos/editorial"
+    QUERY_PARAM_NAMES = ["age_of_people","collection_codes","collections_filter_type","editorial_video_types","entity_uris","exclude_nudity","fields","format_available","frame_rates",
         "keyword_ids","page","page_size","phrase","product_types","sort_order","specific_people"]
 
-	QUERY_PARAMS_NAMES.each do |key|
-    define_method :"with_#{key}" do |value = true| 
-			if value.is_a?(Array)
-				value = value.join(",")
-				if !key.include? "id"
-					value.downcase!
-				end	
-    			build_query_params(key, value)
-			else
-				if (!key.include? "id") && (value.is_a?(String))
-					value.downcase!
-				end	
-    			build_query_params(key, value)
-    		end
-    		return self
-    	end
-  	end
-
-	def with_accept_language(language)
-		@accept_language = {"Accept-Language" => language}
-		return self
+	QUERY_PARAM_NAMES.each do |key|
+		define_method :"with_#{key}" do |value = true| 
+			add_parameter(key, value)
+			return self
+		end
 	end
-
+	
 	def execute
-		return @http_helper.get(API_ROUTE, @query_params, @accept_language)			
+		return @http_helper.get(API_ROUTE, @query_params, @headers)			
 	end
 
 end

--- a/lib/Videos/Videos.rb
+++ b/lib/Videos/Videos.rb
@@ -2,21 +2,17 @@ require_relative "../RequestBase.rb"
 
 class Videos < RequestBase
 
-    attr_accessor :asset_id, :accept_language
+    attr_accessor :asset_id
 
-	API_ROUTE = "/v3/videos" # mashery endpoint	
-	QUERY_PARAMS_NAMES = ["ids","fields"]
+	API_ROUTE = "/v3/videos"
+	QUERY_PARAM_NAMES = ["ids","fields"]
 
-	QUERY_PARAMS_NAMES.each do |key|
-    define_method :"with_#{key}" do |value = true| 
-            value = value.join(",")
-            if !key.include? "id"
-                value.downcase!
-            end	
-            build_query_params(key, value)
-    		return self
-    	end
-  	end
+	QUERY_PARAM_NAMES.each do |key|
+		define_method :"with_#{key}" do |value = true| 
+			add_parameter(key, value)
+			return self
+		end
+	end
 			
 	public 
     def with_id(id)
@@ -24,16 +20,11 @@ class Videos < RequestBase
 		return self
 	end
 
-	public
-	def with_accept_language(language)
-		@accept_language = {"Accept-Language" => language}
-		return self
-	end
 
 	public
     def execute
         self.asset_id.nil? ? uri = API_ROUTE : uri = API_ROUTE + "/" + self.asset_id
-		return @http_helper.get(uri, @query_params, @accept_language)			
+		return @http_helper.get(uri, @query_params, @headers)			
 	end
 
 end

--- a/unit_tests/CustomParamHeaderTests.rb
+++ b/unit_tests/CustomParamHeaderTests.rb
@@ -1,0 +1,36 @@
+require 'test/unit'
+require 'webmock/test_unit'
+require_relative "../lib/ApiClient.rb"
+
+ 
+class CustomParamHeaderTests < Test::Unit::TestCase
+    def setup
+        stub_request(:post, "https://api.gettyimages.com/oauth2/token").with(body: {"client_id"=>"api key", "client_secret"=>"api secret", "grant_type"=>"client_credentials"})
+        .to_return(status: 200, body: '{"access_token": "client_credentials_access_token", "token_types": "Bearer", "expires_in": "1800"}')
+    end
+
+    def test_search_images_creative_with_custom_header
+        stub_request(:get, "https://api.gettyimages.com/v3/search/images/creative").with(headers: {"GI-Country-Code" => "CAN"})
+            .to_return(body: '{ "message": "success" }')
+
+        apiClient 		= ApiClient.new("api key", "api secret")
+        search_results	= apiClient.search_images_creative()
+                            .with_custom_header("GI-Country-Code", "CAN")
+                            .execute()
+
+        assert_equal({"message" => "success"}, search_results.to_hash )
+    end
+
+    def test_search_images_creative_with_custom_parameter
+        stub_request(:get, "https://api.gettyimages.com/v3/search/images/creative").with(query: {"safe_search" => "true"})
+            .to_return(body: '{ "message": "success" }')
+
+        apiClient 		= ApiClient.new("api key", "api secret")
+        search_results	= apiClient.search_images_creative()
+                            .with_custom_parameter("safe_search", "true")
+                            .execute()
+
+        assert_equal({"message" => "success"}, search_results.to_hash )
+    end
+ 
+end


### PR DESCRIPTION
Allows specifying custom parameters and headers on any API request. See
the README.md file of tests for examples.